### PR TITLE
Add themed / monochrome app icon support

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@mipmap/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@mipmap/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
This PR adds the Themed Launcher icon functionality introduced in Android 12L.
Here are some examples of what it looks like:

- Blue Swatch, Dark Theme

<img src="https://github.com/user-attachments/assets/27c0d8de-3dd5-4897-ae58-ac8f5b07f69c" width=25%/>

- Brown Swatch, Light Theme

<img src="https://github.com/user-attachments/assets/5d4142b3-1ccc-4c29-b030-75cfa9abf992" width=25%/>